### PR TITLE
Key events update

### DIFF
--- a/src/components/game/Sketch.tsx
+++ b/src/components/game/Sketch.tsx
@@ -154,7 +154,7 @@ export default ({ game, evaluation }: SketchProps) => {
 
   function currentTime(sketch: p5) { return sketch.millis() }
 
-  function queueEvent(eventId: string) {
+  function queueGameEvent(eventId: string) {
     const { sendMessage } = interpret(evaluation.environment, natives)
     sendMessage('queueEvent', io(evaluation), eventId)(evaluation)
   }
@@ -166,8 +166,8 @@ export default ({ game, evaluation }: SketchProps) => {
     const keyPressedId = evaluation.createInstance('wollok.lang.List', [left, keyPressedCode])
     const anyKeyPressedId = evaluation.createInstance('wollok.lang.List', [left, anyKeyCode])
 
-    queueEvent(keyPressedId)
-    queueEvent(anyKeyPressedId)
+    queueGameEvent(keyPressedId)
+    queueGameEvent(anyKeyPressedId)
     return false
   }
 

--- a/src/components/game/Sketch.tsx
+++ b/src/components/game/Sketch.tsx
@@ -154,12 +154,20 @@ export default ({ game, evaluation }: SketchProps) => {
 
   function currentTime(sketch: p5) { return sketch.millis() }
 
-  function keyPressed(sketch: p5) {
-    const left = evaluation.createInstance('wollok.lang.String', 'keydown')
-    const right = evaluation.createInstance('wollok.lang.String', wKeyCode(sketch.key, sketch.keyCode))
-    const id = evaluation.createInstance('wollok.lang.List', [left, right])
+  function queueEvent(eventId: string) {
     const { sendMessage } = interpret(evaluation.environment, natives)
-    sendMessage('queueEvent', io(evaluation), id)(evaluation)
+    sendMessage('queueEvent', io(evaluation), eventId)(evaluation)
+  }
+
+  function keyPressed(sketch: p5) {
+    const left = evaluation.createInstance('wollok.lang.String', 'keypress')
+    const keyPressedCode = evaluation.createInstance('wollok.lang.String', wKeyCode(sketch.key, sketch.keyCode))
+    const anyKeyCode = evaluation.createInstance('wollok.lang.String', 'ANY')
+    const keyPressedId = evaluation.createInstance('wollok.lang.List', [left, keyPressedCode])
+    const anyKeyPressedId = evaluation.createInstance('wollok.lang.List', [left, anyKeyCode])
+
+    queueEvent(keyPressedId)
+    queueEvent(anyKeyPressedId)
     return false
   }
 


### PR DESCRIPTION
* Cambie el evento del presionado de teclas de 'keydown' a 'keypress' segun [lo cambiado en lang](https://github.com/uqbar-project/wollok-language/pull/68)
* También agregue el envió del 'ANY' junto al presionado de las teclas
* Cambie algunos nombres de variables e hice la función `queueGameEvent`, de la cual no estoy seguro pero me pareció algo apropiado hacerla.

Con esto habría que cambiar de ts los tests que usen 'keydown' por 'keypress' y tal vez agregar un test para el ANY.