### PR TITLE
Draw by layer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: node_js
+node_js: node

--- a/src/components/bytecodeDebugger/Details.tsx
+++ b/src/components/bytecodeDebugger/Details.tsx
@@ -15,7 +15,7 @@ import Context from './Context'
 export type DetailsProp = { }
 
 const Details = ({ }: DetailsProp) => {
-  
+
   const { evaluation, stepThroughEvaluation, setCurrentEvaluationIndex, currentEvaluationIndex, evaluationHistory, stepEvaluation, selectedFrame, garbageCollect } = useContext(EvaluationContext)
 
   const operandStack = selectedFrame?.operandStack?.map<Stackable>(operand => ({ label: <Id id={operand}/> })) ?? []

--- a/src/components/bytecodeDebugger/Utils.tsx
+++ b/src/components/bytecodeDebugger/Utils.tsx
@@ -12,7 +12,7 @@ declare global {
 declare module 'react' {
   interface InputHTMLAttributes<T extends HTMLInputElement> {
     webkitdirectory?: string
-  } 
+  }
 }
 
 

--- a/src/components/game/Sketch.tsx
+++ b/src/components/game/Sketch.tsx
@@ -172,7 +172,7 @@ const SketchComponent = ({ game, evaluation }: SketchProps) => {
     if (JSON.stringify(next) !== current) board = next
   }
 
-  function drawBoard(sketch: p5) { // TODO: Draw by layer, not cell
+  function drawBoard(sketch: p5) {
     const cellPixelSize = cellSize(evaluation)
 
     boardToLayers(board).forEach(layer => {

--- a/src/components/game/Sketch.tsx
+++ b/src/components/game/Sketch.tsx
@@ -6,12 +6,7 @@ import Sketch from 'react-p5'
 import { Evaluation, Id, interpret, WRENatives } from 'wollok-ts'
 import { RuntimeObject } from 'wollok-ts/dist/interpreter'
 import { GameProject } from './Game'
-
-type Cell = {
-  img: string
-  message?: any
-}
-type Board = Cell[][][]
+import { Board, boardToLayers } from './utils'
 
 const io = (evaluation: Evaluation) => evaluation.environment.getNodeByFQN('wollok.io.io').id
 
@@ -138,7 +133,6 @@ const SketchComponent = ({ game, evaluation }: SketchProps) => {
 
 
   const draw = (sketch: p5Types) => {
-    if (!evaluation) return
     flushEvents(evaluation, currentTime(sketch))
     updateBoard()
     drawBoard(sketch)
@@ -181,11 +175,14 @@ const SketchComponent = ({ game, evaluation }: SketchProps) => {
   function drawBoard(sketch: p5) { // TODO: Draw by layer, not cell
     const cellPixelSize = cellSize(evaluation)
 
-    board.forEach((row, _y) => {
-      const y = sketch.height - _y * cellPixelSize
-      row.forEach((cell, _x) => {
-        const x = _x * cellPixelSize
-        cell.forEach(({ img, message }) => {
+    boardToLayers(board).forEach(layer => {
+      layer.forEach((row, _y) => {
+        if (!row) return
+        const y = sketch.height - _y * cellPixelSize
+        row.forEach((actor, _x) => {
+          if (!actor) return
+          const { img, message } = actor
+          const x = _x * cellPixelSize
           const imageObject = imgs[img]
           const yPosition = y - imageObject.height
           sketch.image(imageObject, x, yPosition)

--- a/src/components/game/utils.ts
+++ b/src/components/game/utils.ts
@@ -1,0 +1,31 @@
+
+export type Cell = {
+  img: string;
+  message?: any;
+}
+
+export type Board = Cell[][][]  // y, x, actors
+export type Layer = Cell[][]    // y, x
+
+export const boardToLayers = (board: Board): Layer[] => {
+  return zipLongest(...board.map(line => zipLongest(...line)))
+}
+
+const zipLongest = <T>(...list: T[][]) => {
+  const arrs = list.splice(0)
+
+  const longest = arrs.reduce(function (a, b) {
+    return a.length > b.length ? a : b
+  })
+
+  return returnMap(longest, arrs)
+}
+
+
+function returnMap <T>(shortest: T[], arrs: T[][]) {
+  return shortest.map(function (_item, i) {
+    return arrs.map(function (arr) {
+      return arr[i]
+    })
+  })
+}

--- a/src/test/game.test.ts
+++ b/src/test/game.test.ts
@@ -1,0 +1,32 @@
+import { boardToLayers } from '../components/game/utils'
+
+describe('game', () => {
+  const ground1 = { img: 'ground1' }
+  const ground2 = { img: 'ground2' }
+  const pepita2 = { img: 'pepita2' }
+  const pepita3 = { img: 'pepita3' }
+
+  const board = [
+    [[ground1], [ground1, pepita2], [ground1]],
+    [[ground2], [ground2, pepita2, pepita3], [ground2]],
+  ]
+
+  test('board to layers', () => {
+    const layers = boardToLayers(board)
+    expect(layers).toEqual([
+      [
+        [ground1, ground1, ground1],
+        [ground2, ground2, ground2],
+      ],
+      [
+        [undefined, pepita2, undefined],
+        [undefined, pepita2, undefined],
+      ],
+      [
+        undefined,
+        [undefined, pepita3, undefined],
+      ]
+    ])
+  })
+
+})


### PR DESCRIPTION
En este PR se arregla el orden de renderizado de las celdas, para hacerlo primero por capa.

Antes:
![Selection_210](https://user-images.githubusercontent.com/4098184/92322719-5fbfd200-f009-11ea-9b30-53599699dcb1.png)

Después:
![Selection_216](https://user-images.githubusercontent.com/4098184/92322720-63535900-f009-11ea-983a-e7b3e256a5d0.png)


- Además se crea el primer test (de espero que muchos) :tada: 
- Se agrega Travis