### PR TITLE
Fix de imagenes dentro de carpetas

### DIFF
--- a/src/components/game/Game.tsx
+++ b/src/components/game/Game.tsx
@@ -115,7 +115,7 @@ function buildGameProject(repoUri: string): GameProject {
   const sources = getAllFilePathsFrom(GAME_DIR, EXPECTED_WOLLOK_EXTENSIONS)
   const assetSource = `https://raw.githubusercontent.com/${repoUri}/master/`
   const gameAssetsPaths = getAllFilePathsFrom(GAME_DIR, VALID_MEDIA_EXTENSIONS).map(path => assetSource + path.substr(GAME_DIR.length + 1))
-  const assetFolderName = gameAssetsPaths[0].substring(assetSource.length).split('/')[0]
+  const assetFolderName = gameAssetsPaths[0]?.substring(assetSource.length).split('/')[0]
   const assetsDir = assetSource + assetFolderName + '/'
   const imagePaths = gameAssetsPaths.concat(defaultImagesNeededFor(gameAssetsPaths))
 

--- a/src/components/game/Game.tsx
+++ b/src/components/game/Game.tsx
@@ -18,7 +18,7 @@ const WOLLOK_PROGRAM_EXTENSION = 'wpgm'
 const EXPECTED_WOLLOK_EXTENSIONS = [WOLLOK_FILE_EXTENSION, WOLLOK_PROGRAM_EXTENSION]
 const VALID_MEDIA_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif']
 const GAME_DIR = 'game'
-const DEFAULT_GAME_ASSETS_DIR = 'https://raw.githubusercontent.com/uqbar-project/wollok/dev/org.uqbar.project.wollok.game/assets/'
+export const DEFAULT_GAME_ASSETS_DIR = 'https://raw.githubusercontent.com/uqbar-project/wollok/dev/org.uqbar.project.wollok.game/assets/'
 
 const fetchFile = (path: string) => {
   return {
@@ -32,6 +32,7 @@ export interface GameProject {
   sources: string[]
   description: string
   imagePaths: string[]
+  assetsDir: string
 }
 
 
@@ -114,6 +115,8 @@ function buildGameProject(repoUri: string): GameProject {
   const sources = getAllFilePathsFrom(GAME_DIR, EXPECTED_WOLLOK_EXTENSIONS)
   const assetSource = `https://raw.githubusercontent.com/${repoUri}/master/`
   const gameAssetsPaths = getAllFilePathsFrom(GAME_DIR, VALID_MEDIA_EXTENSIONS).map(path => assetSource + path.substr(GAME_DIR.length + 1))
+  const assetFolderName = gameAssetsPaths[0].substring(assetSource.length).split('/')[0]
+  const assetsDir = assetSource + assetFolderName + '/'
   const imagePaths = gameAssetsPaths.concat(defaultImagesNeededFor(gameAssetsPaths))
 
   let description
@@ -122,7 +125,7 @@ function buildGameProject(repoUri: string): GameProject {
   } catch {
     description = '## No description found'
   }
-  return { main, sources, description, imagePaths }
+  return { main, sources, description, imagePaths, assetsDir }
 }
 
 function defaultImagesNeededFor(imagePaths: string[]): string[] {

--- a/src/components/game/Sketch.tsx
+++ b/src/components/game/Sketch.tsx
@@ -175,8 +175,7 @@ const SketchComponent = ({ game, evaluation }: SketchProps) => {
   }
 
   function imageFromPath(path: string): p5.Image {
-    const posibleImagen = game.assetsDir + path
-    return imgs[posibleImagen] ?? imgs[DEFAULT_GAME_ASSETS_DIR + path] ?? imgs[DEFAULT_GAME_ASSETS_DIR + 'wko.png']
+    return imgs[game.assetsDir + path] ?? imgs[DEFAULT_GAME_ASSETS_DIR + path] ?? imgs[DEFAULT_GAME_ASSETS_DIR + 'wko.png']
   }
 
   function updateBoard() {

--- a/src/components/game/Sketch.tsx
+++ b/src/components/game/Sketch.tsx
@@ -5,7 +5,7 @@ import Sketch from 'react-p5'
 // import 'p5/lib/addons/p5.sound'
 import { Evaluation, Id, interpret, WRENatives } from 'wollok-ts'
 import { RuntimeObject } from 'wollok-ts/dist/interpreter'
-import { GameProject } from './Game'
+import { GameProject, DEFAULT_GAME_ASSETS_DIR } from './Game'
 import { Board, boardToLayers } from './utils'
 
 const io = (evaluation: Evaluation) => evaluation.environment.getNodeByFQN('wollok.io.io').id
@@ -170,12 +170,13 @@ const SketchComponent = ({ game, evaluation }: SketchProps) => {
 
   function loadImages(sketch: p5Types) {
     game.imagePaths.forEach((gamePath: string) => {
-      imgs[gamePath.split('/').pop()!] = sketch.loadImage(gamePath)
+      imgs[gamePath] = sketch.loadImage(gamePath)
     })
   }
 
   function imageFromPath(path: string): p5.Image {
-    return imgs[path] ?? imgs['wko.png']
+    const posibleImagen = game.assetsDir + path
+    return imgs[posibleImagen] ?? imgs[DEFAULT_GAME_ASSETS_DIR + path] ?? imgs[DEFAULT_GAME_ASSETS_DIR + 'wko.png']
   }
 
   function updateBoard() {


### PR DESCRIPTION
Estaba el problema de que si se tiene la imagen de un visual como `image = "personaje/mirandoArriba.png"`, la cual estaria en la direccion "https://github.com/laOrg/elRepo/carpetaAssets/personaje/mirandoArriba.png", no se va a mostrar porque en
https://github.com/uqbar-project/wollok-run-client/blob/34ba8700e1801e980515b2c0c50047376a099ced/src/components/game/Sketch.tsx#L171-L175
`gamePath.split('/').pop()!` guarda nomas el nombre de la imagen, y no el path, por lo que termina guardado el nombre de la imagen como "mirandoArriba.png" y despues en
https://github.com/uqbar-project/wollok-run-client/blob/34ba8700e1801e980515b2c0c50047376a099ced/src/components/game/Sketch.tsx#L177-L179
Se trata de buscar la imagen por "personaje/mirandoArriba.png", y no se encuentra. 

La solución que hice fue hacer que se guarde el path entero directamente. Esto trajo el problema de que al path de la imagen del visual había que agregarle el resto del path, osea a "personaje/mirandoArriba.png" agregarle al principio "https://github.com/laOrg/elRepo/carpetaAssets/". Esto lo solucione haciendo que esa dirección de los assets (`assetsDir`) venga del gameProject. Estaría bueno, si es posible, poder conseguir el nombre de la carpeta donde están los assets de una forma menos fea que la que hice acá.