### PR TITLE
Root images fix

### DIFF
--- a/src/components/game/Sketch.tsx
+++ b/src/components/game/Sketch.tsx
@@ -80,8 +80,9 @@ const SketchComponent = ({ game, evaluation: e }: SketchProps) => {
     defaultImgs.forEach((path: string) => {
       imgs[path] = sketch.loadImage(DEFAULT_GAME_ASSETS_DIR + path)
     })
-    game.images.forEach(({ path, url }) => {
-      imgs[path] = sketch.loadImage(url)
+    game.images.forEach(({ possiblePaths, url }) => {
+      const loadedImage = sketch.loadImage(url)
+      possiblePaths.forEach((path: string) => imgs[path] = loadedImage)
     })
   }
 
@@ -164,15 +165,15 @@ const SketchComponent = ({ game, evaluation: e }: SketchProps) => {
     })
   }
 
-  function getSoundPathFromFileName(fileName: string): string | undefined {
-    return game.sounds.find(({ path }) => path === fileName)?.url
+  function getSoundUrlFromFileName(fileName: string): string | undefined {
+    return game.sounds.find(({ possiblePaths }) => possiblePaths.includes(fileName))?.url
   }
 
   function addSoundFromSoundState(soundState: SoundState) {
     loadedSounds.set(soundState.id,
       {
         lastSoundState: soundState,
-        soundFile: new p5.SoundFile(getSoundPathFromFileName(soundState.file)!), //TODO add soundfile not found exception
+        soundFile: new p5.SoundFile(getSoundUrlFromFileName(soundState.file)!), //TODO add soundfile not found exception
         started: false,
         toBePlayed: false,
       })

--- a/src/components/game/gameProject.ts
+++ b/src/components/game/gameProject.ts
@@ -65,8 +65,8 @@ function getAllSourceFiles(files: File[]): File[] {
 }
 
 function possiblePathsToFile(filePath: string, sourcePaths: string[]): string[] {
-  const possiblePaths: string[] = sourcePaths.filter((source: string) => filePath.startsWith(source))!
-  return possiblePaths.map((sourcePath: string) => filePath.substring(sourcePath.length + 1))
+  const possibleSources: string[] = sourcePaths.filter((source: string) => filePath.startsWith(source))!
+  return possibleSources.map((sourcePath: string) => filePath.substring(sourcePath.length + 1))
 }
 
 function getRootPath(files: File[]): string {

--- a/src/components/game/gameProject.ts
+++ b/src/components/game/gameProject.ts
@@ -54,7 +54,7 @@ function getMediaFiles(allFiles: File[], validExtensions: string[], type: string
   const mediaSourcePaths = getSourcePaths(allFiles).concat(getRootPath(allFiles))
   return mediaFiles.map(({ name, content }) => (
     {
-      possiblePaths: possiblePathsToFile(name, mediaSourcePaths).concat(''),
+      possiblePaths: possiblePathsToFile(name, mediaSourcePaths),
       url: URL.createObjectURL(new Blob([content], { type: type })),
     }
   ))

--- a/src/components/game/gameProject.ts
+++ b/src/components/game/gameProject.ts
@@ -66,12 +66,12 @@ function getAllSourceFiles(files: File[]): File[] {
 
 function possiblePathsToFile(filePath: string, sourcePaths: string[]): string[] {
   const possibleSources: string[] = sourcePaths.filter((source: string) => filePath.startsWith(source))!
-  return possibleSources.map((sourcePath: string) => filePath.substring(sourcePath.length + 1))
+  return possibleSources.map((sourcePath: string) => filePath.substring(sourcePath.length))
 }
 
 function getRootPath(files: File[]): string {
   const classpathPath: string = getClasspathFile(files).name
-  return classpathPath.split(`.${CLASSPATH_NAME}`)[0].slice(0, -1)
+  return classpathPath.split(`.${CLASSPATH_NAME}`)[0]
 }
 
 
@@ -80,7 +80,7 @@ function getSourcePaths(files: File[]): string[] {
   const document: parse.Document = parse(classPathContent)
   const documentAttributes: Attributes[] = document.root.children.map(child => child.attributes)
   const sourceFolderNames = documentAttributes.filter((attribute: Attributes) => attribute.kind === 'src').map((attribute: Attributes) => attribute.path)
-  return sourceFolderNames.map((sourceName: string) => `${getRootPath(files)}/${sourceName}`)
+  return sourceFolderNames.map((sourceName: string) => `${getRootPath(files)}${sourceName}/`)
 }
 
 function getClasspathFile(files: File[]): File {

--- a/src/components/game/gameProject.ts
+++ b/src/components/game/gameProject.ts
@@ -51,10 +51,10 @@ export const buildGameProject = (allFiles: File[]): GameProject => {
 
 function getMediaFiles(allFiles: File[], validExtensions: string[], type: string): MediaFile[] {
   const mediaFiles = allFiles.filter(withExtension(...validExtensions))
-  const sourcePaths = getSourcePaths(allFiles)
+  const mediaSourcePaths = getSourcePaths(allFiles).concat(getRootPath(allFiles))
   return mediaFiles.map(({ name, content }) => (
     {
-      possiblePaths: possiblePathsToFile(name, sourcePaths),
+      possiblePaths: possiblePathsToFile(name, mediaSourcePaths).concat(''),
       url: URL.createObjectURL(new Blob([content], { type: type })),
     }
   ))
@@ -71,7 +71,7 @@ function possiblePathsToFile(filePath: string, sourcePaths: string[]): string[] 
 
 function getRootPath(files: File[]): string {
   const classpathPath: string = getClasspathFile(files).name
-  return classpathPath.split(`.${CLASSPATH_NAME}`)[0]
+  return classpathPath.split(`.${CLASSPATH_NAME}`)[0].slice(0, -1)
 }
 
 
@@ -80,7 +80,7 @@ function getSourcePaths(files: File[]): string[] {
   const document: parse.Document = parse(classPathContent)
   const documentAttributes: Attributes[] = document.root.children.map(child => child.attributes)
   const sourceFolderNames = documentAttributes.filter((attribute: Attributes) => attribute.kind === 'src').map((attribute: Attributes) => attribute.path)
-  return sourceFolderNames.map((sourceName: string) => getRootPath(files) + sourceName)
+  return sourceFolderNames.map((sourceName: string) => `${getRootPath(files)}/${sourceName}`)
 }
 
 function getClasspathFile(files: File[]): File {

--- a/src/components/game/gameProject.ts
+++ b/src/components/game/gameProject.ts
@@ -18,7 +18,7 @@ interface SourceFile {
 }
 
 interface MediaFile {
-  path: string;
+  possiblePaths: string[];
   url: string;
 }
 export interface GameProject {
@@ -37,25 +37,24 @@ export const mainProgram = ({ main }: GameProject, environment: Environment): st
 }
 
 export const buildGameProject = (allFiles: File[]): GameProject => {
-  const sourceFiles = getAllSourceFiles(allFiles)
-
-  const wpgmFile = sourceFiles.find(withExtension(WOLLOK_PROGRAM_EXTENSION))
+  const wollokFiles = getAllSourceFiles(allFiles).filter(withExtension(...EXPECTED_WOLLOK_EXTENSIONS)).map(({ name, content }) => ({ name, content: content.toString('utf8') }))
+  const wpgmFile = wollokFiles.find(withExtension(WOLLOK_PROGRAM_EXTENSION))
   if (!wpgmFile) throw new Error('Program file not found')
   const main = wpgmFile.name.replace(`.${WOLLOK_PROGRAM_EXTENSION}`, '').replace(/\//gi, '.')
-  const wollokFiles = sourceFiles.filter(withExtension(...EXPECTED_WOLLOK_EXTENSIONS)).map(({ name, content }) => ({ name, content: content.toString('utf8') }))
   const description = allFiles.find(withExtension('md'))?.content.toString('utf8') || '## No description found'
 
-  const images = getMediaFiles(sourceFiles, VALID_IMAGE_EXTENSIONS, 'image/png', getSourcePaths(allFiles))
-  const sounds = getMediaFiles(sourceFiles, VALID_SOUND_EXTENSIONS, 'audio/mp3', getSourcePaths(allFiles))
+  const images = getMediaFiles(allFiles, VALID_IMAGE_EXTENSIONS, 'image/png')
+  const sounds = getMediaFiles(allFiles, VALID_SOUND_EXTENSIONS, 'audio/mp3')
 
   return { main, sources: wollokFiles, description, images, sounds }
 }
 
-function getMediaFiles(sourceFiles: File[], validExtensions: string[], type: string, sourcePaths: string[]): MediaFile[] {
-  const mediaFiles = sourceFiles.filter(withExtension(...validExtensions))
+function getMediaFiles(allFiles: File[], validExtensions: string[], type: string): MediaFile[] {
+  const mediaFiles = allFiles.filter(withExtension(...validExtensions))
+  const sourcePaths = getSourcePaths(allFiles)
   return mediaFiles.map(({ name, content }) => (
     {
-      path: filePathWithoutSource(name, sourcePaths),
+      possiblePaths: possiblePathsToFile(name, sourcePaths),
       url: URL.createObjectURL(new Blob([content], { type: type })),
     }
   ))
@@ -65,9 +64,9 @@ function getAllSourceFiles(files: File[]): File[] {
   return files.filter(({ name }) => getSourcePaths(files).some((sourcePath: string) => name.startsWith(sourcePath)))
 }
 
-function filePathWithoutSource(filePath: string, sourcePaths: string[]): string {
-  const sourcePath: string = sourcePaths.find((source: string) => filePath.startsWith(source))!
-  return filePath.substring(sourcePath.length + 1)
+function possiblePathsToFile(filePath: string, sourcePaths: string[]): string[] {
+  const possiblePaths: string[] = sourcePaths.filter((source: string) => filePath.startsWith(source))!
+  return possiblePaths.map((sourcePath: string) => filePath.substring(sourcePath.length + 1))
 }
 
 function getRootPath(files: File[]): string {
@@ -88,5 +87,5 @@ function getClasspathFile(files: File[]): File {
   return files.find(withExtension(CLASSPATH_NAME))!
 }
 
-const withExtension = (...extensions: string[]) => ({ name }: File) =>
+const withExtension = (...extensions: string[]) => ({ name }: File | SourceFile) =>
   extensions.some(extension => name.endsWith(`.${extension}`))


### PR DESCRIPTION
Resolves #41 
Ahora se aceptan paths a imagenes y sonidos que sean de la forma "assets/imagen.png". También se aceptan imágenes que estén en la carpeta raíz. Como ahora hay mas de 1 path posible para la imagen, se cambio un poco la forma de cargar y conseguir las imágenes de parte de sketch. 