### PR TITLE
Readme refactor

### DIFF
--- a/src/components/DrawerReadme.module.scss
+++ b/src/components/DrawerReadme.module.scss
@@ -1,0 +1,43 @@
+@import "../_theme.scss";
+
+.container {
+    display: flex;
+    height: 100%;
+    flex-direction: column;
+    padding: 15vh;
+    font-family: "monospace";
+  
+    & > div {
+      display: flex;
+      margin: auto;
+    }
+  
+    h1 {
+      font-size: 1.5em;
+      margin-bottom: 0vh;
+    }
+
+    .description {
+        display: flex;
+        flex-direction: column;
+        width: 40vw;
+        height: 100%;
+        justify-content: center;
+        margin-left: 1vw;
+        margin-right: 1vw;
+        padding-left: 4vw;
+        border-left: 2px solid $color-primary;
+        overflow: auto;
+        
+        * {
+            color: white;
+        }
+
+        h1{
+          font-size: 3em;
+        }
+        h2{
+          margin: 2vw 2vw 1vw 0;
+        }
+      }
+  }

--- a/src/components/DrawerReadme.tsx
+++ b/src/components/DrawerReadme.tsx
@@ -9,44 +9,42 @@ import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import { ReactNode } from 'react';
 import ReactMarkdown from 'react-markdown';
-import $ from './game/Game.module.scss'
-
+import $ from './DrawerReadme.module.scss'
+import { InnerValue } from 'wollok-ts';
+import { Height } from '@material-ui/icons';
+import { MenuItem } from '@material-ui/core';
 type Anchor = 'top' | 'left' | 'bottom' | 'right';
 
 
 export type DescriptionProps = {
-  description: string
+  description: string,
+  children: ReactNode,
+  close: () => void
 }
-export const DrawerReadme = ({ description }: DescriptionProps) => {
+export const DrawerReadme = ({ description, children }: DescriptionProps) => {
   const [state, setState] = React.useState({
     right: false,
   });
 
   const toggleDrawer =
     (anchor: Anchor, open: boolean) =>
-    (event: React.MouseEvent) => {
+    () => {
       setState({ ...state, [anchor]: open });
     };
-
-  const list = (anchor: Anchor) => (
-    <Box
-      role="presentation"
-      onClick={toggleDrawer(anchor, false)}
-    >
-      <ReactMarkdown source={description} className={$.description} />
-    </Box>
-  );
 
   return (
     <div>
       <React.Fragment key={'right'}>
-          <Button onClick={toggleDrawer('right', true)}>{'right'}</Button>
+          <MenuItem onClick={toggleDrawer('right', true)}>{children}</MenuItem>
           <Drawer
             anchor={'right'}
             open={state['right']}
             onClose={toggleDrawer('right', false)}
+            className={$.container}
           >
-            {list('right')}
+            <div style={{ backgroundColor: '#1c1a1c', height:'100%'}}>
+              <ReactMarkdown source={description} className={$.description}/>
+            </div>
           </Drawer>
         </React.Fragment>
     </div>

--- a/src/components/DrawerReadme.tsx
+++ b/src/components/DrawerReadme.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import Box from '@material-ui/core/Box';
+import Drawer from '@material-ui/core/Drawer';
+import Button from '@material-ui/core/Button';
+import List from '@material-ui/core/List';
+import Divider from '@material-ui/core/Divider';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import { ReactNode } from 'react';
+import ReactMarkdown from 'react-markdown';
+import $ from './game/Game.module.scss'
+
+type Anchor = 'top' | 'left' | 'bottom' | 'right';
+
+
+export type DescriptionProps = {
+  description: string
+}
+export const DrawerReadme = ({ description }: DescriptionProps) => {
+  const [state, setState] = React.useState({
+    right: false,
+  });
+
+  const toggleDrawer =
+    (anchor: Anchor, open: boolean) =>
+    (event: React.MouseEvent) => {
+      setState({ ...state, [anchor]: open });
+    };
+
+  const list = (anchor: Anchor) => (
+    <Box
+      role="presentation"
+      onClick={toggleDrawer(anchor, false)}
+    >
+      <ReactMarkdown source={description} className={$.description} />
+    </Box>
+  );
+
+  return (
+    <div>
+      <React.Fragment key={'right'}>
+          <Button onClick={toggleDrawer('right', true)}>{'right'}</Button>
+          <Drawer
+            anchor={'right'}
+            open={state['right']}
+            onClose={toggleDrawer('right', false)}
+          >
+            {list('right')}
+          </Drawer>
+        </React.Fragment>
+    </div>
+  );
+}

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -6,19 +6,20 @@ import MenuIcon from '@material-ui/icons/Menu'
 import ReplayIcon from '@material-ui/icons/Replay'
 import PlaylistPlayIcon from '@material-ui/icons/PlaylistPlay'
 import MenuBookIcon from '@material-ui/icons/MenuBook'
+import { DrawerReadme } from './DrawerReadme'
 // import VolumeOffIcon from '@material-ui/icons/VolumeOff'
 // import VolumeUpIcon from '@material-ui/icons/VolumeUp'
 // import PauseIcon from '@material-ui/icons/Pause'
 // import PlayArrowIcon from '@material-ui/icons/PlayArrow'
 
 type MenuProps = {
-  restart: () => void
-  exit: () => void
+  restart: () => void,
+  exit: () => void,
+  gameDescription: string,
 }
 
 export default function SimpleMenu(props: MenuProps) {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
-  const [readmeOpen, setReadmeOpen] = useState(false)
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget)
@@ -27,19 +28,7 @@ export default function SimpleMenu(props: MenuProps) {
   const handleClose = () => {
     setAnchorEl(null)
   }
-
-  const toggleReadme = () => {
-    setReadmeOpen(!readmeOpen)
-  }
   
-
-  const ReadmeItem = () => {
-    if(readmeOpen) {
-      return <><MenuBookIcon /> Abrir Readme</>
-    }
-    return <><MenuBookIcon /> Cerrar Readme</>
-  }
-
   return (
     <div>
       <Button aria-controls="simple-menu" aria-haspopup="true" onClick={handleClick} variant="contained" color="primary">
@@ -58,9 +47,9 @@ export default function SimpleMenu(props: MenuProps) {
         <MenuItem onClick={event => { event.preventDefault(); props.exit(); setAnchorEl(null) }}>
           <PlaylistPlayIcon /> Elegir juego
         </MenuItem>
-        <MenuItem onClick={event => { event.preventDefault(); toggleReadme(); setAnchorEl(null) }}>
-          <ReadmeItem />
-        </MenuItem>
+        <DrawerReadme description={props.gameDescription} close={handleClose} >
+          <MenuBookIcon /> Abrir Readme 
+        </DrawerReadme>
         {/* <MenuItem onClick={handleClose}>
             <PauseIcon />Pausar juego
           </MenuItem>

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,10 +1,11 @@
-import React from 'react'
+import React, { useState } from 'react'
 import Button from '@material-ui/core/Button'
 import Menu from '@material-ui/core/Menu'
 import MenuItem from '@material-ui/core/MenuItem'
 import MenuIcon from '@material-ui/icons/Menu'
 import ReplayIcon from '@material-ui/icons/Replay'
 import PlaylistPlayIcon from '@material-ui/icons/PlaylistPlay'
+import MenuBookIcon from '@material-ui/icons/MenuBook'
 // import VolumeOffIcon from '@material-ui/icons/VolumeOff'
 // import VolumeUpIcon from '@material-ui/icons/VolumeUp'
 // import PauseIcon from '@material-ui/icons/Pause'
@@ -17,6 +18,7 @@ type MenuProps = {
 
 export default function SimpleMenu(props: MenuProps) {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
+  const [readmeOpen, setReadmeOpen] = useState(false)
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget)
@@ -24,6 +26,18 @@ export default function SimpleMenu(props: MenuProps) {
 
   const handleClose = () => {
     setAnchorEl(null)
+  }
+
+  const toggleReadme = () => {
+    setReadmeOpen(!readmeOpen)
+  }
+  
+
+  const ReadmeItem = () => {
+    if(readmeOpen) {
+      return <><MenuBookIcon /> Abrir Readme</>
+    }
+    return <><MenuBookIcon /> Cerrar Readme</>
   }
 
   return (
@@ -43,6 +57,9 @@ export default function SimpleMenu(props: MenuProps) {
         </MenuItem>
         <MenuItem onClick={event => { event.preventDefault(); props.exit(); setAnchorEl(null) }}>
           <PlaylistPlayIcon /> Elegir juego
+        </MenuItem>
+        <MenuItem onClick={event => { event.preventDefault(); toggleReadme(); setAnchorEl(null) }}>
+          <ReadmeItem />
         </MenuItem>
         {/* <MenuItem onClick={handleClose}>
             <PauseIcon />Pausar juego

--- a/src/components/game/Game.module.scss
+++ b/src/components/game/Game.module.scss
@@ -19,22 +19,4 @@
     font-size: 1.5em;
     margin-bottom: 2vh;
   }
-
-  .description {
-    display: flex;
-    flex-direction: column;
-    width: 40%;
-    max-height: 80vh;
-    margin-left: 1vw;
-    padding-left: 4vw;
-    border-left: 2px solid $color-primary;
-    overflow: auto;
-
-    h1{
-      font-size: 3em;
-    }
-    h2{
-      margin: 2vw 2vw 1vw 0;
-    }
-  }
 }

--- a/src/components/game/Game.tsx
+++ b/src/components/game/Game.tsx
@@ -53,7 +53,6 @@ const Game = (_: GameProps) => {
     <h1>{title}</h1>
     <div>
       <Sketch gameProject={game} evaluation={evaluation} exit={backToFS} />
-      <DrawerReadme description={game.description} />
     </div>
   </div>
 }

--- a/src/components/game/Game.tsx
+++ b/src/components/game/Game.tsx
@@ -8,6 +8,7 @@ import Sketch from './Sketch'
 import $ from './Game.module.scss'
 import { GameProject, buildGameProject, getProgramIn } from './gameProject'
 import { LoadProgramError } from './LoadProgramError'
+import { DrawerReadme } from '../DrawerReadme'
 
 export type GameProps = RouteComponentProps
 const Game = (_: GameProps) => {
@@ -52,7 +53,7 @@ const Game = (_: GameProps) => {
     <h1>{title}</h1>
     <div>
       <Sketch gameProject={game} evaluation={evaluation} exit={backToFS} />
-      <ReactMarkdown source={game.description} className={$.description} />
+      <DrawerReadme description={game.description} />
     </div>
   </div>
 }

--- a/src/components/game/Sketch.tsx
+++ b/src/components/game/Sketch.tsx
@@ -225,7 +225,7 @@ const SketchComponent = ({ gameProject, evaluation: initialEvaluation, exit }: S
     {stop
       ? <h1>Se terminó el juego</h1>
       : <Sketch setup={setup} draw={draw} keyPressed={keyPressed} />}
-    <Menu restart={restart} exit={exit} />
+    <Menu restart={restart} exit={exit} gameDescription={gameProject.description}/>
   </div>
 }
 


### PR DESCRIPTION
Reference #51 

Para tener más espacio para los juegos, sacamos el README.md de la pantalla inicial. Ahora se ve solo el juego y en el menú hay una opción para desplegar el readme.
![sinReadme (1)](https://user-images.githubusercontent.com/46464403/133846914-89002aac-c060-481e-970f-b9d932b2804b.png)
![menuReadme](https://user-images.githubusercontent.com/46464403/133846923-e71df9d5-1dcb-4a2c-8e5b-fd3cd793be45.png)
![conReadme](https://user-images.githubusercontent.com/46464403/133846928-a5dac974-2bf2-427f-bbc0-599d6720395b.png)


Esto va a ser movido a una barra de herramientas arriba como está propuesto [acá](https://github.com/uqbar-project/wollok-run-client/issues/51#issuecomment-917218945)