### PR TITLE
Validations

### DIFF
--- a/src/components/game/Game.tsx
+++ b/src/components/game/Game.tsx
@@ -1,6 +1,6 @@
 import { RouteComponentProps } from '@reach/router'
 import React, { memo, useEffect, useState } from 'react'
-import { buildEnvironment, Evaluation, WRENatives } from 'wollok-ts'
+import { buildEnvironment, Environment, Evaluation, validate, WRENatives } from 'wollok-ts'
 import interpret from 'wollok-ts/dist/interpreter/interpreter'
 import FilesSelector, { File } from '../filesSelector/FilesSelector'
 import Sketch from './Sketch'
@@ -27,10 +27,21 @@ const Game = (_: GameProps) => {
     loadGame(files, program)
   }
 
+  const validateGame = (environment: Environment) => {
+    const problems = validate(environment)
+    const warnings = problems.filter(problem => problem.level === 'warning')
+
+    if (warnings.length){
+      console.error(`FOUND ${warnings.length} PROBLEMS IN LOADED GAME!`, warnings)
+    }
+    else console.info('NO PROBLEMS FOUND IN LOADED GAME!')
+  }
+
   const loadGame = (files: File[], program?: string) => {
     try {
       const project = buildGameProject(files, program)
       const environment = buildEnvironment(project.sources)
+      validateGame(environment)
       const interpreter = interpret(environment, WRENatives)
       interpreter.exec(getProgramIn(project.main, environment))
       setGame(project)

--- a/src/components/game/LoadError.tsx
+++ b/src/components/game/LoadError.tsx
@@ -101,11 +101,15 @@ function validationMessage(problems: List<Problem>) {
 }
 
 function problemMessage(problem: Problem) {
-  return `Problem code: ${problem.code} starting ${problemLocation(problem, sourceMapStart)} and ending ${problemLocation(problem, sourceMapEnd)}.`
+  return `Problem code: ${problem.code} in file ${humanizeFile(problem)}. Starting ${problemLocation(problem, sourceMapStart)} and ending ${problemLocation(problem, sourceMapEnd)}.`
 }
 
 function problemLocation(problem: Problem, location: (problem: Problem) => Parsimmon.Index | undefined) {
   return `in line ${humanizedLocation(location(problem)?.line)} on column ${humanizedLocation(location(problem)?.column)}`
+}
+
+function humanizeFile(problem: Problem) {
+  return problem.node.sourceFileName() || 'unknown'
 }
 
 function humanizedLocation(num: number | undefined){

--- a/src/components/game/LoadError.tsx
+++ b/src/components/game/LoadError.tsx
@@ -4,6 +4,15 @@ import { MultiProgramException, NoProgramException } from './gameProject'
 import { BaseErrorScreen } from '../ErrorScreen'
 import $ from './Game.module.scss'
 import { ProgramSelector } from '../ProgramSelector'
+import { List } from 'wollok-ts'
+import { Problem } from 'wollok-ts/dist/validator'
+import { Button } from '@material-ui/core'
+import PublishIcon from '@material-ui/icons/Publish'
+
+export interface ValidationErrorProps {
+  problems: List<Problem>
+  callback: () => void
+}
 
 export interface LoadErrorProps {
   error: Error
@@ -30,6 +39,31 @@ export function LoadError(props: LoadErrorProps) {
     return <NoProgramError />
 
   return <GenericError { ... { error } }/>
+}
+
+export function ValidationError({ problems, callback }: ValidationErrorProps) {
+  const props = {
+    description: 'Se encontraron algunos problemas que pueden impedir que el juego se ejecute con normalidad. ¿Desea correrlo de todos modos?',
+    children: (
+      <>
+        <br />
+        <textarea
+          className={$.errorMessage}
+          readOnly
+          value='Hubieron problemas de validacion' //TODO: USE PROBLEMS TO CREATE A BETTER MESSAGE
+        />
+      </>
+    ),
+    bottom: {
+      children: (
+        <Button style={{ float: 'right' }} startIcon={<PublishIcon />} onClick={() => callback() } variant="contained" color="primary">
+          Cargar Juego
+        </Button>
+      ),
+    },
+  }
+
+  return <BaseErrorScreen { ... props } />
 }
 
 function NoProgramError() {

--- a/src/components/game/LoadError.tsx
+++ b/src/components/game/LoadError.tsx
@@ -8,6 +8,7 @@ import { List } from 'wollok-ts'
 import { Problem } from 'wollok-ts/dist/validator'
 import { Button } from '@material-ui/core'
 import PublishIcon from '@material-ui/icons/Publish'
+import Parsimmon from 'parsimmon'
 
 export interface ValidationErrorProps {
   problems: List<Problem>
@@ -50,13 +51,13 @@ export function ValidationError({ problems, callback }: ValidationErrorProps) {
         <textarea
           className={$.errorMessage}
           readOnly
-          value='Hubieron problemas de validacion' //TODO: USE PROBLEMS TO CREATE A BETTER MESSAGE
+          value= { 'Hubo problemas de validacion: \n' + validationMessage(problems)} //TODO: USE PROBLEMS TO CREATE A BETTER MESSAGE
         />
       </>
     ),
     bottom: {
       children: (
-        <Button style={{ float: 'right' }} startIcon={<PublishIcon />} onClick={() => callback() } variant="contained" color="primary">
+        <Button style={{ float: 'right' }} startIcon={<PublishIcon />} onClick={ callback } variant="contained" color="primary">
           Cargar Juego
         </Button>
       ),
@@ -93,4 +94,28 @@ function GenericError({ error }: GenericErrorProps) {
   }
 
   return <BaseErrorScreen { ... props } />
+}
+
+function validationMessage(problems: List<Problem>) {
+  return problems.map(problem => problemMessage(problem)).join("\n")
+}
+
+function problemMessage(problem: Problem) {
+  return `Problem code: ${problem.code} starting ${problemLocation(problem, sourceMapStart)} and ending ${problemLocation(problem, sourceMapEnd)}.`
+}
+
+function problemLocation(problem: Problem, location: (problem: Problem) => Parsimmon.Index | undefined) {
+  return `in line ${humanizedLocation(location(problem)?.line)} on column ${humanizedLocation(location(problem)?.column)}`
+}
+
+function humanizedLocation(num: number | undefined){
+  return num ? num : 'unknown'
+}
+
+function sourceMapStart(problem: Problem) {
+  return problem.sourceMap?.start
+}
+
+function sourceMapEnd(problem: Problem) {
+  return problem.sourceMap?.end
 }

--- a/src/components/game/Sketch.tsx
+++ b/src/components/game/Sketch.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useState } from 'react'
 import Sketch from 'react-p5'
 import 'p5/lib/addons/p5.sound'
 import { Evaluation, Id } from 'wollok-ts'
-import validate from 'wollok-ts/dist/validator'
 import { Interpreter } from 'wollok-ts/dist/interpreter/interpreter'
 import { GameProject, DEFAULT_GAME_ASSETS_DIR } from './gameProject'
 import { GameSound, SoundState, SoundStatus } from './GameSound'
@@ -156,14 +155,6 @@ const SketchComponent = ({ gameProject, evaluation: initialEvaluation, exit }: S
   const images = new Map<string, p5.Image>()
   const sounds = new Map<Id, GameSound>()
   let interpreter = new Interpreter(initialEvaluation.copy())
-
-  useEffect(() => {
-    // TODO: Move out of sketch
-    const problems = validate(initialEvaluation.environment)
-    if (problems.length) {
-      console.error(`FOUND ${problems.length} PROBLEMS IN LOADED GAME!`, problems)
-    } else console.info('NO PROBLEMS FOUND IN LOADED GAME!')
-  }, [initialEvaluation])
 
   useEffect(() => {
     setInterval(() => {


### PR DESCRIPTION
Fix #90

Pareciera que todavía no hay validaciones que generen errores. Lo que estuve haciendo para simular eso es lo siguiente:

```typescript
   const errors: List<Problem> = validationProblems.map(problem => { return { ...problem, level: 'error' } } )
```

Transformo los warnings en errores. Podría ponerle un error directamente pero quiero ver cómo se va a visualizar toda esa info en la pantalla más adelante.

Por ahora se ve así:

![image](https://user-images.githubusercontent.com/31800576/134615299-2e45f3d8-d983-47d4-8c8d-380f6b1fc945.png)

Lo que está dentro del recuadro es un placeholder. Hay que pensar cómo mostrar toda la info que tienen los Problems en forma de string. O pensar una estrategia diferente.

No lo tiré a master porque creé la branch a partir de `environment-errors`. Así no aparecen todos los cambios de esa branch.

Juego de prueba: https://github.com/pdepjm/2020-o-tpi-juego-los4
