### PR TITLE
Resizing canvas

### DIFF
--- a/src/components/game/SketchUtils.ts
+++ b/src/components/game/SketchUtils.ts
@@ -3,7 +3,7 @@ import { RuntimeObject } from 'wollok-ts'
 import { Interpreter } from 'wollok-ts/dist/interpreter/interpreter'
 import { TEXT_SIZE, TEXT_STYLE } from './messages'
 
-const { round } = Math
+const { round, min } = Math
 
 function invokeMethod(interpreter: Interpreter, visual: RuntimeObject, method: string) {
   const lookedUpMethod = visual.module.lookupMethod(method, 0)
@@ -138,6 +138,18 @@ export function flushEvents(interpreter: Interpreter, ms: number): void {
 export interface CanvasResolution {
   width: number;
   height: number;
+  ratio: number;
+}
+
+
+function resize(gameWidth: number, gameHeight: number) {
+  const screenWidth = window.innerWidth
+  const screenHeight = window.innerHeight
+  const ratio = min(screenWidth / gameWidth, screenHeight / gameHeight);
+  const width = gameWidth*ratio
+  const height = gameHeight*ratio
+
+  return { width, height, ratio }
 }
 
 export function canvasResolution(interpreter: Interpreter): CanvasResolution {
@@ -145,7 +157,8 @@ export function canvasResolution(interpreter: Interpreter): CanvasResolution {
   const cellPixelSize = game.get('cellSize')!.innerNumber!
   const width = round(game.get('width')!.innerNumber!) * cellPixelSize
   const height = round(game.get('height')!.innerNumber!) * cellPixelSize
-  return { width, height }
+
+  return resize(width, height)
 }
 
 export function queueEvent(interpreter: Interpreter, ...events: RuntimeObject[]): void {


### PR DESCRIPTION
Fix #89 

Este PR es más para iniciar la conversación de mañana, momenteamente hice esto para mantener el aspect ratio al escalar el canvas:
```typescript
function resize(gameWidth: number, gameHeight: number) {
  const screenWidth = window.innerWidth
  const screenHeight = window.innerHeight
  const ratio = min(screenWidth / gameWidth, screenHeight / gameHeight);
  const width = gameWidth*ratio
  const height = gameHeight*ratio

  return { width, height, ratio }
}
``` 
El problema es: El tamaño de las celdas también hay que adaptarlo, para ello, hay que pasarle este mismo ratio que se usa al calcular los tamaños, a la celda. Cual es el problema con esto? el canvasResolution se calcula en el setup de sketch, el tamaño de las celdas está dentro de render(), lo cual se llama en step(), osea, la forma de pasarle este ratio a la celda, es seguir extendiendo los parámetros de step, y me gustaría intentar evitar eso.

Dejo dos ejemplos, uno mostrando el problema con no ajustar el tamaño de las celdas, y otro de como se ve con esta implementación, después tengo que poner en consideración el tamaño del menú al hacer el resizing, pero momenteaneamente queda la scrollbar solo por el burger.
Celdas sin modificar: 
![sketchResized](https://user-images.githubusercontent.com/46464403/134654260-7019a514-693c-4211-932f-d8b479ab53f8.png)

Celdas modificadas:
![sketchResized (1)](https://user-images.githubusercontent.com/46464403/134654274-8193c6ba-c7c2-4a63-b782-9b11fe129eac.png)


