### PR TITLE
Resize using CSS style

### DIFF
--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -20,6 +20,7 @@ type MenuProps = {
   toggleAudio: () => void
   togglePause: () => void
   gameDescription: string
+  menuSize: number
 }
 
 export default function SimpleMenu(props: MenuProps) {
@@ -77,7 +78,7 @@ export default function SimpleMenu(props: MenuProps) {
 
   return (
     <div>
-      <Button aria-controls="simple-menu" aria-haspopup="true" onClick={handleClick} variant="contained" color="primary">
+      <Button style={{height: `${props.menuSize}vh`}} aria-controls="simple-menu" aria-haspopup="true" onClick={handleClick} variant="contained" color="primary">
         <MenuIcon />
       </Button>
       <Menu

--- a/src/components/game/Sketch.tsx
+++ b/src/components/game/Sketch.tsx
@@ -9,7 +9,7 @@ import { Interpreter } from 'wollok-ts/dist/interpreter/interpreter'
 import { GameProject, DEFAULT_GAME_ASSETS_DIR } from './gameProject'
 import { GameSound, SoundState, SoundStatus } from './GameSound'
 import { DrawableMessage, drawMessage } from './messages'
-import { buildKeyPressEvent, visualState, flushEvents, canvasResolution, queueEvent, hexaToColor, baseDrawable, draw, moveAllTo, write } from './SketchUtils'
+import { buildKeyPressEvent, visualState, flushEvents, canvasResolution, queueEvent, hexaToColor, baseDrawable, draw, moveAllTo, write, resizeCanvas } from './SketchUtils'
 import Menu from '../Menu'
 
 const { round } = Math
@@ -226,6 +226,7 @@ const SketchComponent = ({ gameProject, evaluation: initialEvaluation, exit }: S
         images.set(path, sketch.loadImage(url))
       )
     )
+    resizeCanvas(width, height)
   }
 
   function draw(sketch: p5) {

--- a/src/components/game/Sketch.tsx
+++ b/src/components/game/Sketch.tsx
@@ -182,6 +182,7 @@ const SketchComponent = ({ gameProject, evaluation: initialEvaluation, exit }: S
   const images = new Map<string, p5.Image>()
   const sounds = new Map<Id, GameSound>()
   let interpreter = new Interpreter(initialEvaluation.copy())
+  const menuSize = 4
 
   useEffect(() => {
     // TODO: Move out of sketch
@@ -226,7 +227,7 @@ const SketchComponent = ({ gameProject, evaluation: initialEvaluation, exit }: S
         images.set(path, sketch.loadImage(url))
       )
     )
-    resizeCanvas(width, height)
+    resizeCanvas(width, height, menuSize)
   }
 
   function draw(sketch: p5) {
@@ -261,7 +262,7 @@ const SketchComponent = ({ gameProject, evaluation: initialEvaluation, exit }: S
     {stop
       ? <h1>Se terminó el juego</h1>
       : <Sketch setup={setup} draw={draw} keyPressed={keyPressed} />}
-    <Menu restart={restart} exit={exit} gameDescription={gameProject.description} toggleAudio={toggleAudio} togglePause={togglePause} />
+    <Menu menuSize={menuSize} restart={restart} exit={exit} gameDescription={gameProject.description} toggleAudio={toggleAudio} togglePause={togglePause} />
   </div>
 }
 

--- a/src/components/game/SketchUtils.ts
+++ b/src/components/game/SketchUtils.ts
@@ -161,11 +161,13 @@ function canvasAspectRatio(gameWidth: number, gameHeight: number) {
   return ratio 
 }
 
-export function resizeCanvas(gameWidth: number, gameHeight: number) {
+export function resizeCanvas(gameWidth: number, gameHeight: number, menuSize: number) {
   const canvas = document.getElementById('defaultCanvas0')
   const ratio = canvasAspectRatio(gameWidth, gameHeight)
+  const menuOffset = window.innerHeight / 100 * menuSize * 2
+  
   canvas?.style.removeProperty('width')
   canvas?.style.removeProperty('height')
   canvas!.style.width = `${gameWidth * ratio}px`
-  canvas!.style.height = `${gameHeight * ratio}px`
+  canvas!.style.height = `${gameHeight * ratio - menuOffset}px`
 }

--- a/src/components/game/SketchUtils.ts
+++ b/src/components/game/SketchUtils.ts
@@ -3,7 +3,7 @@ import { RuntimeObject } from 'wollok-ts'
 import { Interpreter } from 'wollok-ts/dist/interpreter/interpreter'
 import { TEXT_SIZE, TEXT_STYLE } from './messages'
 
-const { round } = Math
+const { round, min } = Math
 
 function invokeMethod(interpreter: Interpreter, visual: RuntimeObject, method: string) {
   const lookedUpMethod = visual.module.lookupMethod(method, 0)
@@ -151,4 +151,21 @@ export function canvasResolution(interpreter: Interpreter): CanvasResolution {
 export function queueEvent(interpreter: Interpreter, ...events: RuntimeObject[]): void {
   const io = interpreter.object('wollok.io.io')
   events.forEach(e => interpreter.send('queueEvent', io, e))
+}
+
+function canvasAspectRatio(gameWidth: number, gameHeight: number) {
+  const screenWidth = window.innerWidth
+  const screenHeight = window.innerHeight
+  const ratio = min(screenWidth / gameWidth, screenHeight / gameHeight);
+
+  return ratio 
+}
+
+export function resizeCanvas(gameWidth: number, gameHeight: number) {
+  const canvas = document.getElementById('defaultCanvas0')
+  const ratio = canvasAspectRatio(gameWidth, gameHeight)
+  canvas?.style.removeProperty('width')
+  canvas?.style.removeProperty('height')
+  canvas!.style.width = `${gameWidth * ratio}px`
+  canvas!.style.height = `${gameHeight * ratio}px`
 }


### PR DESCRIPTION
Fix #89 

Ahora se ajusta el tamaño utilizando getDocumentById en vez de meterse dentro del P5, dejo acá dos ejemplos:

![maximumSize (1)](https://user-images.githubusercontent.com/46464403/134736245-e38d446e-0dbe-4b78-a761-f04025589940.png)

![maximumSize](https://user-images.githubusercontent.com/46464403/134736232-2c65c1b8-2ea2-466f-b80a-d07e03e2c4d2.png)

Sigue estando el tema de que hay que tener en consideración el tamaño del menú al hacer el resizing, pero momenteaneamente queda la scrollbar solo por el burger.