### PR TITLE
New menu in shape of a toolbar

### DIFF
--- a/src/components/DrawerReadme.module.scss
+++ b/src/components/DrawerReadme.module.scss
@@ -2,7 +2,7 @@
 
 .container {
     display: flex;
-    height: 100%;
+    height: 100vh;
     flex-direction: column;
     padding: 15vh;
     font-family: "monospace";
@@ -21,10 +21,12 @@
         display: flex;
         flex-direction: column;
         width: 40vw;
-        height: 100%;
+        height: 100vh;
         justify-content: center;
         margin-left: 1vw;
         margin-right: 1vw;
+        padding-top: 10vh;
+        padding-bottom: 1vh;
         padding-left: 4vw;
         border-left: 2px solid $color-primary;
         overflow: auto;

--- a/src/components/DrawerReadme.tsx
+++ b/src/components/DrawerReadme.tsx
@@ -1,34 +1,32 @@
 import * as React from 'react'
 import Drawer from '@material-ui/core/Drawer'
-import { ReactNode } from 'react'
+import { ReactNode, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import $ from './DrawerReadme.module.scss'
-import { MenuItem } from '@material-ui/core'
-type Anchor = 'top' | 'left' | 'bottom' | 'right'
+import { IconButton } from '@material-ui/core'
 
 
 export type DescriptionProps = {
   description: string
   children: ReactNode
-  close: () => void
 }
 export const DrawerReadme = ({ description, children }: DescriptionProps) => {
-  const [state, setState] = React.useState({ right: false })
+  const [state, setState] = useState({ right: false })
 
   const toggleDrawer =
-    (anchor: Anchor, open: boolean) =>
+    (open: boolean) =>
       () => {
-        setState({ ...state, [anchor]: open })
+        setState({ ...state, ['right']: open })
       }
 
   return (
     <div>
       <React.Fragment key={'right'}>
-        <MenuItem onClick={toggleDrawer('right', true)}>{children}</MenuItem>
+        <IconButton style={{color: 'white'}} onClick={toggleDrawer(true)}>{children}</IconButton>
         <Drawer
           anchor={'right'}
           open={state['right']}
-          onClose={toggleDrawer('right', false)}
+          onClose={toggleDrawer(false)}
           className={$.container}
         >
           <div style={{ backgroundColor: '#1c1a1c', height:'100%' }}>

--- a/src/components/Menu.module.scss
+++ b/src/components/Menu.module.scss
@@ -1,0 +1,13 @@
+@import "../_theme.scss";
+
+.navContainer {
+    flex: center;
+    justify-content: center;
+}
+
+.toolbar {
+    justify-content: space-between;
+    & > button {
+        color: white;
+      }
+}

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,10 +1,6 @@
 import React, { useState } from 'react'
-import Button from '@material-ui/core/Button'
-import Menu from '@material-ui/core/Menu'
-import MenuItem from '@material-ui/core/MenuItem'
-import MenuIcon from '@material-ui/icons/Menu'
 import ReplayIcon from '@material-ui/icons/Replay'
-import PlaylistPlayIcon from '@material-ui/icons/PlaylistPlay'
+import CloseIcon from '@material-ui/icons/Close'
 import VolumeOffIcon from '@material-ui/icons/VolumeOff'
 import VolumeUpIcon from '@material-ui/icons/VolumeUp'
 import PauseCircleFilledIcon from '@material-ui/icons/PauseCircleFilled'
@@ -13,6 +9,8 @@ import FullscreenIcon from '@material-ui/icons/Fullscreen'
 import FullscreenExitIcon from '@material-ui/icons/FullscreenExit'
 import MenuBookIcon from '@material-ui/icons/MenuBook'
 import { DrawerReadme } from './DrawerReadme'
+import { AppBar, IconButton, Toolbar, Tooltip } from '@material-ui/core'
+import $ from './Menu.module.scss'
 
 type MenuProps = {
   restart: () => void
@@ -24,18 +22,10 @@ type MenuProps = {
 }
 
 export default function SimpleMenu(props: MenuProps) {
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const [mute, setMute] = useState(false)
   const [pause, setPause] = useState(false)
   const [fullscreen, setFullscreen] = useState(false)
-
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    setAnchorEl(event.currentTarget)
-  }
-
-  const handleClose = () => {
-    setAnchorEl(null)
-  }
+  const caca = `dasdas${"asd"}`
 
   const toggleAudio = () => {
     setMute(!mute)
@@ -55,58 +45,85 @@ export default function SimpleMenu(props: MenuProps) {
     setFullscreen(!fullscreen)
   }
 
+  const fullscreenText = () => {
+    return fullscreen ? "Salir de pantalla completa" : "Pantalla completa"
+  }
+
   const AudioItem = () => {
     if(mute) {
-      return <><VolumeUpIcon /> Reanudar audio</>
+      return <>
+      <Tooltip title="Reanudar audio">
+        <VolumeUpIcon />
+      </Tooltip>
+      </>
     }
-    return <><VolumeOffIcon /> Silenciar audio</>
+    return <>
+    <Tooltip title="Silenciar audio">
+      <VolumeOffIcon />
+    </Tooltip>
+    </>
   }
 
   const TogglePauseItem = () => {
     if(pause) {
-      return <><PlayCircleFilledIcon /> Reanudar juego</>
+      return <>
+      <Tooltip title="Reanudar juego">
+        <PlayCircleFilledIcon />
+      </Tooltip>
+      </>
     }
-    return <><PauseCircleFilledIcon /> Pausar juego</>
+    return <>
+    <Tooltip title="Pausar juego">
+      <PauseCircleFilledIcon />
+    </Tooltip>
+    </>
   }
 
   const FullscreenItem = () => {
     if(fullscreen) {
-      return <><FullscreenExitIcon /> Salir de pantalla completa</>
+      return <>
+      <Tooltip title="Salir de pantalla completa">
+        <FullscreenExitIcon />
+      </Tooltip>
+      </>
     }
-    return <><FullscreenIcon /> Pantalla completa</>
+    return <>
+    <Tooltip title="Pantalla completa">
+      <FullscreenIcon />
+    </Tooltip>
+    </>
   }
 
   return (
     <div>
-      <Button style={{height: `${props.menuSize}vh`}} aria-controls="simple-menu" aria-haspopup="true" onClick={handleClick} variant="contained" color="primary">
-        <MenuIcon />
-      </Button>
-      <Menu
-        id="simple-menu"
-        anchorEl={anchorEl}
-        keepMounted
-        open={Boolean(anchorEl)}
-        onClose={handleClose}
-      >
-        <MenuItem onClick={event => { event.preventDefault(); props.togglePause(); togglePause(); setAnchorEl(null) }}>
-          <TogglePauseItem />
-        </MenuItem>
-        <MenuItem onClick={event => { event.preventDefault(); props.toggleAudio(); toggleAudio(); setAnchorEl(null) }}>
-          <AudioItem/>
-        </MenuItem>
-        <MenuItem onClick={event => { event.preventDefault(); props.restart(); setAnchorEl(null) }}>
-          <ReplayIcon />Reiniciar juego
-        </MenuItem>
-        <MenuItem onClick={event => { event.preventDefault(); props.exit(); setAnchorEl(null) }}>
-          <PlaylistPlayIcon /> Elegir juego
-        </MenuItem>
-        <DrawerReadme description={props.gameDescription} close={handleClose} >
-          <MenuBookIcon /> Abrir Readme
-        </DrawerReadme>
-        <MenuItem onClick={event => { event.preventDefault(); toggleFullscreen(); setAnchorEl(null) }}>
-          <FullscreenItem/>
-        </MenuItem>
-      </Menu>
+      <AppBar className={$.navContainer} position="static" style={{ height: `${props.menuSize}vh` }}>
+        <Toolbar className={$.toolbar}>
+          <IconButton onClick={event => { event.preventDefault(); props.restart(); }}>
+            <Tooltip title="Reiniciar juego">
+              <ReplayIcon />
+            </Tooltip>
+          </IconButton>
+          <IconButton onClick={event => { event.preventDefault(); props.togglePause(); togglePause() }}>
+            <TogglePauseItem />
+          </IconButton>
+          <IconButton onClick={event => { event.preventDefault(); props.toggleAudio(); toggleAudio() }}>
+            <AudioItem/>
+          </IconButton>
+          <DrawerReadme description={props.gameDescription} >
+            <Tooltip title="Abrir README">
+            <MenuBookIcon />
+            </Tooltip>
+          </DrawerReadme>
+          <IconButton onClick={event => { event.preventDefault(); toggleFullscreen(); }}>
+            <FullscreenItem/>
+          </IconButton>
+          <IconButton onClick={event => { event.preventDefault(); props.exit(); }}>
+            <Tooltip title="Cerrar juego">
+              <CloseIcon />
+            </Tooltip>
+          </IconButton>
+        </Toolbar>
+      </AppBar>
     </div>
   )
 }

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -7,10 +7,12 @@ import PauseCircleFilledIcon from '@material-ui/icons/PauseCircleFilled'
 import PlayCircleFilledIcon from '@material-ui/icons/PlayCircleFilled'
 import FullscreenIcon from '@material-ui/icons/Fullscreen'
 import FullscreenExitIcon from '@material-ui/icons/FullscreenExit'
+import PublishIcon from '@material-ui/icons/Publish'
 import MenuBookIcon from '@material-ui/icons/MenuBook'
 import { DrawerReadme } from './DrawerReadme'
 import { AppBar, IconButton, Toolbar, Tooltip } from '@material-ui/core'
 import $ from './Menu.module.scss'
+import { ModalFileSelector } from './ModalFileSelector'
 
 type MenuProps = {
   restart: () => void
@@ -113,6 +115,11 @@ export default function SimpleMenu(props: MenuProps) {
             <MenuBookIcon />
             </Tooltip>
           </DrawerReadme>
+          <ModalFileSelector>
+            <Tooltip title="Cargar juego">
+              <PublishIcon />
+            </Tooltip>
+          </ModalFileSelector>
           <IconButton onClick={event => { event.preventDefault(); toggleFullscreen(); }}>
             <FullscreenItem/>
           </IconButton>

--- a/src/components/ModalFileSelector.module.scss
+++ b/src/components/ModalFileSelector.module.scss
@@ -1,0 +1,11 @@
+@import "../_theme.scss";
+
+.box {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 400px;
+    border: 2px solid #000;
+    padding: 3vh;
+}

--- a/src/components/ModalFileSelector.tsx
+++ b/src/components/ModalFileSelector.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import {Box, IconButton, Typography, Modal} from '@material-ui/core'
+import $ from './ModalFileSelector.module.scss'
+import { ReactNode } from 'react';
+
+export type ModalProps = {
+    children: ReactNode
+  }
+export const ModalFileSelector = ({ children }: ModalProps) => {
+  const [open, setOpen] = React.useState(false);
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
+  return (
+    <div>
+      <IconButton style={{color: 'white'}} onClick={handleOpen}> {children} </IconButton>
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="modal-modal-title"
+        aria-describedby="modal-modal-description"
+      >
+        <Box className={$.box}>
+            <Typography id="modal-modal-title" variant="h6" component="h2">
+            Lorem Ipsum jest tekstem stosowanym jako przykładowy wypełniacz w przemyśle poligraficznym. 
+            Został po raz pierwszy użyty w XV w. przez nieznanego drukarza do wypełnienia tekstem próbnej książki. 
+            Pięć wieków później zaczął być używany przemyśle elektronicznym, pozostając praktycznie niezmienionym. 
+            Spopularyzował się w latach 60. XX w. wraz z publikacją arkuszy Letrasetu, zawierających fragmenty Lorem Ipsum,
+             a ostatnio z zawierającym różne wersje Lorem Ipsum oprogramowaniem przeznaczonym do realizacji druków na komputerach
+              osobistych, jak Aldus PageMaker
+            </Typography>
+        </Box>
+      </Modal>
+    </div>
+  );
+}

--- a/src/components/game/Game.tsx
+++ b/src/components/game/Game.tsx
@@ -7,6 +7,7 @@ import Sketch from './Sketch'
 import $ from './Game.module.scss'
 import { GameProject, buildGameProject, getProgramIn } from './gameProject'
 import { LoadProgramError } from './LoadProgramError'
+import { AppBar, Button, Toolbar } from '@material-ui/core'
 
 export type GameProps = RouteComponentProps
 const Game = (_: GameProps) => {

--- a/src/components/game/Sketch.tsx
+++ b/src/components/game/Sketch.tsx
@@ -11,6 +11,7 @@ import { GameSound, SoundState, SoundStatus } from './GameSound'
 import { DrawableMessage, drawMessage } from './messages'
 import { buildKeyPressEvent, visualState, flushEvents, canvasResolution, queueEvent, hexaToColor, baseDrawable, draw, moveAllTo, write, resizeCanvas } from './SketchUtils'
 import Menu from '../Menu'
+import { AppBar, Button, Toolbar } from '@material-ui/core'
 
 const { round } = Math
 
@@ -259,10 +260,19 @@ const SketchComponent = ({ gameProject, evaluation: initialEvaluation, exit }: S
   }
 
   return <div>
+     <Menu 
+      menuSize={menuSize}
+      restart={restart}
+      exit={exit}
+      gameDescription={gameProject.description}
+      toggleAudio={toggleAudio}
+      togglePause={togglePause} 
+     />
+    <div>
     {stop
       ? <h1>Se terminó el juego</h1>
       : <Sketch setup={setup} draw={draw} keyPressed={keyPressed} />}
-    <Menu menuSize={menuSize} restart={restart} exit={exit} gameDescription={gameProject.description} toggleAudio={toggleAudio} togglePause={togglePause} />
+    </div> 
   </div>
 }
 


### PR DESCRIPTION
Reference #51 

Empezada una barra de herramientas. Utilizando material UI tenía dos opciones, que haya un leve overlap sobre el sketch, o que quede ligada al tamaño del juego, la segunda opción nos pareció mejor y mediante un `justify-content: space-between` se acomoda acorde al tamaño de este.

Luego falta tener en consideración el tema de la estructura del proyecto y cómo vamos a manejar el file selector y la recomendación de juegos.