### PR TITLE
Los botones se deseleccionan correctamente

### DIFF
--- a/src/components/DrawerReadme.tsx
+++ b/src/components/DrawerReadme.tsx
@@ -5,11 +5,14 @@ import ReactMarkdown from 'react-markdown'
 import $ from './DrawerReadme.module.scss'
 import { IconButton } from '@material-ui/core'
 import { Parent } from './utils'
+import { unselectButton } from './Menu'
 
 
 interface DescriptionProps extends Parent {
   description: string
 }
+
+const readmeID = 'readmeID'
 
 export const DrawerReadme = ({ description, children }: DescriptionProps) => {
   const [state, setState] = useState({ right: false })
@@ -17,13 +20,14 @@ export const DrawerReadme = ({ description, children }: DescriptionProps) => {
   const toggleDrawer =
     (open: boolean) =>
       () => {
+        unselectButton(readmeID)
         setState({ ...state, right: open })
       }
 
   return (
     <div>
       <React.Fragment key={'right'}>
-        <IconButton style={{ color: 'white' }} onClick={ toggleDrawer(true) }>{ children }</IconButton>
+        <IconButton id={readmeID} style={{ color: 'white' }} onClick={ toggleDrawer(true) }>{ children }</IconButton>
         <Drawer
           anchor={'right'}
           open={state['right']}

--- a/src/components/DrawerReadme.tsx
+++ b/src/components/DrawerReadme.tsx
@@ -3,9 +3,8 @@ import Drawer from '@material-ui/core/Drawer'
 import { useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import $ from './DrawerReadme.module.scss'
-import { IconButton } from '@material-ui/core'
 import { Parent } from './utils'
-import { unselectButton } from './Menu'
+import { MenuButton, unselectButton } from './Menu'
 
 
 interface DescriptionProps extends Parent {
@@ -27,7 +26,7 @@ export const DrawerReadme = ({ description, children }: DescriptionProps) => {
   return (
     <div>
       <React.Fragment key={'right'}>
-        <IconButton id={readmeID} style={{ color: 'white' }} onClick={ toggleDrawer(true) }>{ children }</IconButton>
+        <MenuButton id={readmeID} style={{ color: 'white' }} action={ toggleDrawer(true) }>{ children }</MenuButton>
         <Drawer
           anchor={'right'}
           open={state['right']}

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { ReactNode, useState } from 'react'
 import ReplayIcon from '@material-ui/icons/Replay'
 import CloseIcon from '@material-ui/icons/Close'
 import VolumeOffIcon from '@material-ui/icons/VolumeOff'
@@ -105,25 +105,25 @@ export default function SimpleMenu(props: MenuProps) {
               <MenuBookIcon />
             </Tooltip>
           </DrawerReadme>
-          <IconButton id={pauseID} onClick={event => { buttonStuff(event, pauseID); props.togglePause(); togglePause() }}>
+          <MenuButton id={pauseID} action={ () => { props.togglePause(); togglePause() }}>
             <TogglePauseItem />
-          </IconButton>
-          <IconButton id={audioID} onClick={event => { buttonStuff(event, audioID); props.toggleAudio(); toggleAudio(); }}>
+          </MenuButton>
+          <MenuButton id={audioID} action={ () => { props.toggleAudio(); toggleAudio() }}>
             <AudioItem/>
-          </IconButton>
+          </MenuButton>
           {/* <ModalFileSelector>
             <Tooltip title="Cargar juego">
               <PublishIcon />
             </Tooltip>
           </ModalFileSelector> */}
-          <IconButton id={fullscreenID} onClick={event => { buttonStuff(event, fullscreenID); toggleFullscreen() }}>
+          <MenuButton id={fullscreenID} action={ toggleFullscreen }>
             <FullscreenItem/>
-          </IconButton>
-          <IconButton id={restartGameID} onClick={event => { buttonStuff(event, restartGameID); props.restart() }}>
+          </MenuButton>
+          <MenuButton id={restartGameID} action={ props.restart }>
             <Tooltip title="Reiniciar juego">
               <ReplayIcon />
             </Tooltip>
-          </IconButton>
+          </MenuButton>
           <IconButton onClick={event => { event.preventDefault(); props.exit() }}>
             <Tooltip title="Cerrar juego">
               <CloseIcon />
@@ -132,6 +132,21 @@ export default function SimpleMenu(props: MenuProps) {
         </Toolbar>
       </AppBar>
     </div>
+  )
+}
+
+interface MenuButtonProps{
+  id: string
+  action: () => void
+  style?: { color: string }
+  children: ReactNode
+}
+
+export const MenuButton = ({ id, action, style, children }: MenuButtonProps) => {
+  return(
+    <IconButton id={id} style={style} onClick={event => { buttonStuff(event, pauseID); action() }}>
+      { children }
+    </IconButton>
   )
 }
 

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -14,6 +14,12 @@ import { AppBar, IconButton, Toolbar, Tooltip } from '@material-ui/core'
 import $ from './Menu.module.scss'
 // import { ModalFileSelector } from './ModalFileSelector'
 
+//Buttons id's
+const pauseID = 'pauseID'
+const audioID = 'audioID'
+const fullscreenID = 'fullscreenID'
+const restartGameID = 'restartGameID'
+
 type MenuProps = {
   restart: () => void
   exit: () => void
@@ -90,7 +96,6 @@ export default function SimpleMenu(props: MenuProps) {
       </Tooltip>
     </>
   }
-
   return (
     <div>
       <AppBar className={$.navContainer} position="static" style={{ height: `${props.menuSize}vh` }}>
@@ -100,10 +105,10 @@ export default function SimpleMenu(props: MenuProps) {
               <MenuBookIcon />
             </Tooltip>
           </DrawerReadme>
-          <IconButton onClick={event => { event.preventDefault(); props.togglePause(); togglePause() }}>
+          <IconButton id={pauseID} onClick={event => { buttonStuff(event, pauseID); props.togglePause(); togglePause() }}>
             <TogglePauseItem />
           </IconButton>
-          <IconButton onClick={event => { event.preventDefault(); props.toggleAudio(); toggleAudio() }}>
+          <IconButton id={audioID} onClick={event => { buttonStuff(event, audioID); props.toggleAudio(); toggleAudio(); }}>
             <AudioItem/>
           </IconButton>
           {/* <ModalFileSelector>
@@ -111,10 +116,10 @@ export default function SimpleMenu(props: MenuProps) {
               <PublishIcon />
             </Tooltip>
           </ModalFileSelector> */}
-          <IconButton onClick={event => { event.preventDefault(); toggleFullscreen() }}>
+          <IconButton id={fullscreenID} onClick={event => { buttonStuff(event, fullscreenID); toggleFullscreen() }}>
             <FullscreenItem/>
           </IconButton>
-          <IconButton onClick={event => { event.preventDefault(); props.restart() }}>
+          <IconButton id={restartGameID} onClick={event => { buttonStuff(event, restartGameID); props.restart() }}>
             <Tooltip title="Reiniciar juego">
               <ReplayIcon />
             </Tooltip>
@@ -128,4 +133,13 @@ export default function SimpleMenu(props: MenuProps) {
       </AppBar>
     </div>
   )
+}
+
+export function unselectButton(button: string) {
+  document.getElementById(button)?.blur()
+}
+
+function buttonStuff(event: React.MouseEvent, button: string) {
+  event.preventDefault()
+  unselectButton(button)
 }


### PR DESCRIPTION
Fix #110 

Al seleccionar un botón del menú, no se deseleccionaba y si tocabas enter en el juego podías tener conflicto con esto, ahora estamos usando la función [blur](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/blur) para deseleccionarlos apenas lo llamamos.