### PR TITLE
Corregido estilo de los readme muy extensos

### DIFF
--- a/src/components/DrawerReadme.module.scss
+++ b/src/components/DrawerReadme.module.scss
@@ -33,8 +33,12 @@
           color: white;
       }
 
-      h1{
+      h1 {
         font-size: 3em;
+      }
+
+      img {
+        width: 60%;
       }
     }
   }

--- a/src/components/DrawerReadme.module.scss
+++ b/src/components/DrawerReadme.module.scss
@@ -18,28 +18,29 @@
     }
 
     .description {
-        display: flex;
-        flex-direction: column;
-        width: 40vw;
-        height: 100vh;
-        justify-content: center;
-        margin-left: 1vw;
-        margin-right: 1vw;
-        padding-top: 10vh;
-        padding-bottom: 1vh;
-        padding-left: 4vw;
-        border-left: 2px solid $color-primary;
-        overflow: auto;
-        
-        * {
-            color: white;
-        }
-
-        h1{
-          font-size: 3em;
-        }
-        h2{
-          margin: 2vw 2vw 1vw 0;
-        }
+      display: flex;
+      flex-direction: column;
+      width: 40vw;
+      height: 100%;
+      justify-content: center;
+      margin-left: 1vw;
+      margin-right: 1vw;
+      padding-top: 40rem;
+      padding-bottom: 3rem;
+      padding-left: 3rem;
+      padding-right: 3rem;
+      border-left: 2px solid $color-primary;
+      overflow: auto;
+      
+      * {
+          color: white;
       }
+
+      h1{
+        font-size: 3em;
+      }
+      h2{
+        margin: 2vw 2vw 1vw 0;
+      }
+    }
   }

--- a/src/components/DrawerReadme.module.scss
+++ b/src/components/DrawerReadme.module.scss
@@ -25,10 +25,7 @@
       justify-content: center;
       margin-left: 1vw;
       margin-right: 1vw;
-      padding-top: 40rem;
-      padding-bottom: 3rem;
-      padding-left: 3rem;
-      padding-right: 3rem;
+      padding: 3rem;
       border-left: 2px solid $color-primary;
       overflow: auto;
       
@@ -38,9 +35,6 @@
 
       h1{
         font-size: 3em;
-      }
-      h2{
-        margin: 2vw 2vw 1vw 0;
       }
     }
   }


### PR DESCRIPTION
Fix #127

Los README muy largos se veían así:
![drawerold](https://user-images.githubusercontent.com/46464403/141358149-820d11a2-b197-4ccf-ad23-65ffd2bd0e6d.png)

Ahora con un poco de padding arriba, pasó a verse así:
 
![drawernew](https://user-images.githubusercontent.com/46464403/141358181-f9cc6810-ba0e-43fd-b2a7-47ea7b6836c1.png)

