### PR TITLE
Volado boton de volver a inicio

### DIFF
--- a/src/components/filesSelector/FilesSelector.tsx
+++ b/src/components/filesSelector/FilesSelector.tsx
@@ -40,7 +40,7 @@ const FilesSelector = ({ children, ...props }: FilesSelectorProps & Parent) => {
   return loading
     ? <Spinner />
     : <div className={$.container}>
-      <Link  to={'/'}>
+      <Link to={'/'}>
         <WollokLogo />
       </Link>
       <div>

--- a/src/components/filesSelector/FilesSelector.tsx
+++ b/src/components/filesSelector/FilesSelector.tsx
@@ -4,9 +4,9 @@ import LocalSelector from './LocalSelector'
 import Spinner from '../Spinner'
 import $ from './FilesSelector.module.scss'
 import { WollokLogo } from '../Home/Home'
-import { BackArrow } from '../BackArrow'
 import { BaseErrorScreen } from '../ErrorScreen'
 import { Parent } from '../utils'
+import { Link } from '@reach/router'
 
 export type File = {
   name: string
@@ -40,8 +40,9 @@ const FilesSelector = ({ children, ...props }: FilesSelectorProps & Parent) => {
   return loading
     ? <Spinner />
     : <div className={$.container}>
-      <div><BackArrow returnPath='/' /></div>
-      <WollokLogo />
+      <Link  to={'/'}>
+        <WollokLogo />
+      </Link>
       <div>
         <GitSelector {...props} onStartLoad={onStartLoad} onFailureDo={onFailureDo}/>
         <LocalSelector {...props} onStartLoad={onStartLoad} />


### PR DESCRIPTION
Ahora se puede volver a la pantalla anterior usando el logo de wollok, ya no es necesario el botón.

![image](https://user-images.githubusercontent.com/46464403/145647210-6d1e74ad-f816-4f09-85a8-f302d25237e7.png)
